### PR TITLE
Initial work to get Brotli4j building on FreeBSD-aarch64

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -140,6 +140,10 @@ public class Brotli4jLoader {
             } else if (archName.equalsIgnoreCase("aarch64")) {
                 return "osx-aarch64";
             }
+        } else if (osName.startsWith("FreeBSD")) {
+            if (archName.equalsIgnoreCase("aarch64")) {
+                return "freebsd-aarch64";
+            } 
         }
         throw new UnsupportedOperationException("Unsupported OS and Architecture: " + osName + ", " + archName);
     }

--- a/build-brotli4j.sh
+++ b/build-brotli4j.sh
@@ -1,0 +1,10 @@
+#!/usr/local/bin/bash
+
+# variables
+export JAVA_HOME="/home/woodhamc/template-aarch64-jdk17u/build/bsd-aarch64-template-aarch64-release/images/jdk"
+export MAVEN_OPTS="-Xint -XX:-UseCompressedClassPointers -XX:-UseCompressedOops -Xms4G -Xmx4G -XX:+UseSerialGC"
+
+
+cd /home/woodhamc/Brotli4j
+
+mvn clean package

--- a/natives/freebsd-aarch64/build.sh
+++ b/natives/freebsd-aarch64/build.sh
@@ -12,8 +12,6 @@ function exitWithError() {
 
 mkdir -p "$TARGET_CLASSES_PATH"
 
-echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> HERE HERE HERE HERE HERE HERE HERE"
-
 cd "$TARGET_PATH"
 cmake ../../../ || exitWithError $?
 make || exitWithError $?

--- a/natives/freebsd-aarch64/build.sh
+++ b/natives/freebsd-aarch64/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CURPATH=$(pwd)
+TARGET_CLASSES_PATH="target/classes/lib/freebsd-aarch64"
+TARGET_PATH="target"
+
+function exitWithError() {
+  cd ${CURPATH}
+  echo "*** An error occurred. Please check log messages. ***"
+  exit $1
+}
+
+mkdir -p "$TARGET_CLASSES_PATH"
+
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> HERE HERE HERE HERE HERE HERE HERE"
+
+cd "$TARGET_PATH"
+cmake ../../../ || exitWithError $?
+make || exitWithError $?
+rm -f "$CURPATH/${TARGET_CLASSES_PATH}/libbrotli.so"
+cp "./libbrotli.so" "$CURPATH/${TARGET_CLASSES_PATH}" || exitWithError $?
+
+cd "${CURPATH}"

--- a/natives/freebsd-aarch64/pom.xml
+++ b/natives/freebsd-aarch64/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2021, Aayush Atharva
+
+  Brotli4j licenses this file to you under the
+  Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>natives</artifactId>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <version>1.12.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>native-freebsd-aarch64</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.freebsd.aarch64</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC2</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>17</jvmVersion>
+                            <module>
+                                <moduleInfoSource>
+                                    module ${javaModuleName} {
+                                    requires com.aayushatharva.brotli4j.service;
+                                    exports ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    provides com.aayushatharva.brotli4j.service.BrotliNativeProvider with
+                                    ${javaModuleName}.NativeLoader;
+                                    }
+                                </moduleInfoSource>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>17</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>freebsd-aarch64</id>
+            <activation>
+                <os>
+                    <family>FreeBSD</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>/usr/local/bin/bash</executable>
+                                    <arguments>
+                                        <argument>build.sh</argument>
+                                    </arguments>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>resources</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+
+    </profiles>
+
+</project>

--- a/natives/freebsd-aarch64/src/main/java/com/aayushatharva/brotli4j/macos/aarch64/NativeLoader.java
+++ b/natives/freebsd-aarch64/src/main/java/com/aayushatharva/brotli4j/macos/aarch64/NativeLoader.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright (c) 2020-2023, Aayush Atharva
+ *
+ *    Brotli4j licenses this file to you under the
+ *    Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.aayushatharva.brotli4j.macos.aarch64;
+
+import com.aayushatharva.brotli4j.service.BrotliNativeProvider;
+
+/**
+ * Service class to access the native lib in a JPMS context
+ */
+public class NativeLoader implements BrotliNativeProvider {
+
+    @Override
+    public String platformName() {
+        return "freebsd-aarch64";
+    }
+}

--- a/natives/pom.xml
+++ b/natives/pom.xml
@@ -35,6 +35,7 @@
         <module>windows-x86_64</module>
         <module>osx-x86_64</module>
         <module>osx-aarch64</module>
+        <module>freebsd-aarch64</module>
     </modules>
 
     <dependencies>
@@ -139,6 +140,19 @@
         </profile>
 
         <profile>
+            <id>freebsd-aarch64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <modules>
+                <module>freebsd-aarch64</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>release</id>
             <modules>
                 <module>linux-x86_64</module>
@@ -148,6 +162,7 @@
                 <module>windows-x86_64</module>
                 <module>osx-x86_64</module>
                 <module>osx-aarch64</module>
+                <module>freebsd-aarch64</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
- The native component successfully compiles and creates a shared object; but in its current state the Brotli4jLoader is unable to find the shared object.

